### PR TITLE
Added support for unassigning JIRA issues

### DIFF
--- a/jiraclient/jiraclient.py
+++ b/jiraclient/jiraclient.py
@@ -716,6 +716,17 @@ class Jiraclient(object):
     result = self.call_api('post',uri,payload=comment)
     return result
 
+  def is_assignee_unassigned(self, issue):
+    return issue.has_key('assignee') and issue['assignee'].has_key('name') and issue['assignee']['name'] == 'Unassigned'
+
+  def fix_assignee(self, issue):
+    if self.is_assignee_unassigned(issue):
+      new_issue = issue.copy()
+      new_issue['assignee']['name'] = None
+      return new_issue
+    else:
+      return issue
+
   def clean_issue(self,issue):
     # We have an Issue with a number of required default values
     # that are often empty.  Remove the empty ones so as to not
@@ -730,6 +741,7 @@ class Jiraclient(object):
       if v == {"key":None}: issue.pop(k)
       if v == {"originalEstimate":None}: issue.pop(k)
       if v == [{"id":None}]: issue.pop(k)
+    issue = self.fix_assignee(issue)
     self.logger.debug("cleaned issue: %s" % issue)
     return issue
 

--- a/jiraclient/jiraclient.py
+++ b/jiraclient/jiraclient.py
@@ -140,6 +140,9 @@ class Jiraclient(object):
  - Create an issue with a specified Component and Fix Version 
    and assign it to myself:
    jiraclient.py -u 'username' -p 'jirapassword' -A 'username' -P INFOSYS -Q major -F 10000  -C 10003 -T epic -S 'Investigate Platform IFS'
+
+ - Unassign an existing issue:
+   jiraclient.py -u 'username' -p 'jirapassword' -i INFO-1000 -A Unassigned
 """
     optParser = OptionParser(usage)
     optParser.add_option(
@@ -301,7 +304,7 @@ class Jiraclient(object):
       "-A","--assignee",
       action="store",
       dest="assignee",
-      help="Jira assignee",
+      help="Jira assignee (specify Unassigned to unassign the issue)",
       default=None,
     )
     optParser.add_option(


### PR DESCRIPTION
I added support for unassigning JIRA issues.  I settled on using the word "Unassigned", which matches what users see when observing issues in JIRA through its UI.  The REST API will perform an unassignment when assignee=null.  I chose a magic value approach for now for least disruption to existing dependencies.

An alternative magic value could be the string "null", but this feels more like an implementation detail, a quirk of the REST interface.  Another alternative would be an explicit --unassign option/command.  There is some precedence for this with the --delete command.  Possibly, we could clean up the entire jiraclient interface with a subcommand-plus-options approach, similar to what git uses, which would be helpful for separating the notions of search from modification.  I have avoided the bigger architecture issues with the choice of simple magic value.
